### PR TITLE
feat: Macro invite deletation

### DIFF
--- a/src/@types/env.d.ts
+++ b/src/@types/env.d.ts
@@ -6,6 +6,7 @@ interface Env {
   MATCHMAKING_ANNOUNCE_CHANNEL_ID: string;
   MATCHMAKING_WAITING_CHANNEL_ID: string;
   MATCHMAKED_ROOM_CATEGORY_ID: string;
+  BAN_INVITE_GUILDS: string;
   MASTER_USERS: string;
   NODE_ENV: "production" | "development";
   MONGO_URL: string;

--- a/src/Vars.ts
+++ b/src/Vars.ts
@@ -8,10 +8,10 @@ export default class Vars {
   static dmLogChannel: Discord.TextChannel;
   static matchMakingAnnounceChannel: Discord.TextChannel;
   static matchMakingWaitingChannel: Discord.VoiceBasedChannel;
+  static banInviteGuilds: string[];
 
   public static async init(client: DiscordX.Client): Promise<void> {
     Vars.client = client;
-
     await Promise.all([
       client.guilds
         .fetch(process.env.TEST_GUILD_ID)
@@ -41,6 +41,7 @@ export default class Vars {
         .then((c) => Vars.validateChannel(c, ChannelType.GuildText))
         .then((c) => (Vars.matchMakingAnnounceChannel = c)),
     ]);
+    Vars.banInviteGuilds = process.env.BAN_INVITE_GUILDS.split(",");
   }
 
   public static validateChannel<CT extends ChannelType>(

--- a/src/constants/PColors.ts
+++ b/src/constants/PColors.ts
@@ -1,0 +1,5 @@
+enum PColors {
+  primary = "#2B2D31", // 고정 임베드용
+  error = "#EF1212", // 에러 임베드용
+}
+export default PColors;

--- a/src/core/FixedMessageRegister.ts
+++ b/src/core/FixedMessageRegister.ts
@@ -25,7 +25,7 @@ export default class FixedMessageRegister {
     console.time("initalizing FixedMessageRegister...");
     const messages = await FixedMessageModel.find();
     await Promise.all(
-      messages.map(async (fixedMessageData) => {
+      messages.map((fixedMessageData) =>
         Promise.all([
           Vars.mainGuild.channels
             .fetch(fixedMessageData.channelId)
@@ -38,11 +38,10 @@ export default class FixedMessageRegister {
           FixedMessageModel.deleteOne({
             messageId: fixedMessageData.messageId,
           }),
-        ]);
-      }),
-    );
-
-    console.timeEnd("initalizing FixedMessageRegister...");
+        ]),
+      ),
+    ),
+      console.timeEnd("initalizing FixedMessageRegister...");
   }
 
   public static async sendMessage(

--- a/src/core/ProfileRegister.ts
+++ b/src/core/ProfileRegister.ts
@@ -10,6 +10,7 @@ import throwInteraction from "@/utils/throwInteraction";
 import { contentDataset } from "@/constants/contentDataset";
 import UserModel from "@/models/UserModel";
 import { createComponents } from "@/utils/createComponent";
+import PColors from "@/constants/PColors";
 
 export default class ProfileRegister {
   profile: Profile = {
@@ -39,6 +40,7 @@ export default class ProfileRegister {
     const message = await this.interaction.editReply({
       embeds: [
         new EmbedBuilder()
+          .setColor(PColors.primary)
           .setTitle("프로필 등록에 오신 것을 환영합니다!")
           .setDescription(
             `
@@ -214,6 +216,7 @@ ${italic("프로필 등록은 다시할 수 있습니다.")}
             interaction.reply({
               embeds: [
                 new EmbedBuilder()
+                  .setColor(PColors.error)
                   .setTitle("이런!")
                   .setDescription("가젯은 총 3개만 가능합니다!")
                   .setColor(Colors.Red),

--- a/src/discord/commands/AdminService.ts
+++ b/src/discord/commands/AdminService.ts
@@ -8,9 +8,9 @@ import {
   ComponentType,
   EmbedBuilder,
   bold,
-  codeBlock,
 } from "discord.js";
 import Vars from "@/Vars";
+import PColors from "@/constants/PColors";
 
 @Discord()
 export default class AdminService {
@@ -38,7 +38,7 @@ export default class AdminService {
     await interaction.editReply({
       embeds: [
         new EmbedBuilder()
-          .setColor(Colors.Blue)
+          .setColor(PColors.primary)
           .setTitle("개인메시지 보내기")
           .setDescription(
             `
@@ -65,7 +65,7 @@ DM 메시지를 보내려면 이 채널에 메시지를 보내주세요.
     const confirmAskMessage = await userMessage.reply({
       embeds: [
         new EmbedBuilder()
-          .setColor(Colors.Blue)
+          .setColor(PColors.primary)
           .setTitle("메시지 확인")
           .setDescription(
             `정말로 아래 메시지를 ${target.displayName}님에게 전송하시겠습니까?`,
@@ -103,7 +103,7 @@ DM 메시지를 보내려면 이 채널에 메시지를 보내주세요.
     const dmMessage = await dmChannel.send({
       embeds: [
         new EmbedBuilder()
-          .setColor(Colors.Blue)
+          .setColor(PColors.primary)
           .setTitle("서버메신저")
           .setDescription(messageOptions.content),
       ],
@@ -124,7 +124,7 @@ DM 메시지를 보내려면 이 채널에 메시지를 보내주세요.
     const logMessage = await Vars.dmLogChannel.send({
       embeds: [
         new EmbedBuilder()
-          .setColor(Colors.Blue)
+          .setColor(PColors.primary)
           .setTitle(target.displayName + "님에게 DM을 보냈습니다.")
           .setDescription(`### 내용\n${messageOptions.content}`),
       ],
@@ -140,7 +140,7 @@ DM 메시지를 보내려면 이 채널에 메시지를 보내주세요.
     }
 
     const checkEmbed = new EmbedBuilder()
-      .setColor(Colors.Green)
+      .setColor(PColors.primary)
       .setTitle("확인됨")
       .setDescription(
         bold(interaction.user.displayName) + "님이 DM을 확인했습니다",

--- a/src/discord/commands/HelpService.ts
+++ b/src/discord/commands/HelpService.ts
@@ -1,5 +1,6 @@
 import { Slash, Discord, MetadataStorage } from "discordx";
 import { EmbedBuilder, inlineCode } from "discord.js";
+import PColors from "@/constants/PColors";
 
 @Discord()
 export default class HelpService {
@@ -20,7 +21,10 @@ export default class HelpService {
       )
       .join("");
 
-    const embed = new EmbedBuilder().setTitle("명령어").setDescription(fields);
+    const embed = new EmbedBuilder()
+      .setColor(PColors.primary)
+      .setTitle("명령어")
+      .setDescription(fields);
 
     interaction.reply({
       embeds: [embed],

--- a/src/discord/commands/OtherService.ts
+++ b/src/discord/commands/OtherService.ts
@@ -1,5 +1,6 @@
 import { Slash, Discord } from "discordx";
 import { Colors, EmbedBuilder } from "discord.js";
+import PColors from "@/constants/PColors";
 
 @Discord()
 export default class OtherService {
@@ -10,7 +11,7 @@ export default class OtherService {
   ping(interaction: Discord.ChatInputCommandInteraction) {
     const ping = Date.now() - interaction.createdTimestamp;
     const embed = new EmbedBuilder()
-      .setColor(Colors.White)
+      .setColor(PColors.primary)
       .setTitle("ping: " + ping + "ms");
     interaction.reply({ embeds: [embed] });
   }

--- a/src/discord/commands/UserService.ts
+++ b/src/discord/commands/UserService.ts
@@ -20,6 +20,7 @@ import {
 import throwInteraction from "@/utils/throwInteraction";
 import ProfileRegister from "@/core/ProfileRegister";
 import UserModel from "@/models/UserModel";
+import PColors from "@/constants/PColors";
 
 @SlashGroup({
   name: "프로필",
@@ -118,9 +119,9 @@ export default class UserService {
       interaction.reply({
         embeds: [
           new EmbedBuilder()
+            .setColor(PColors.error)
             .setTitle("이런!")
-            .setDescription("프로필을 모두 입력해주세요!")
-            .setColor(Colors.Red),
+            .setDescription("프로필을 모두 입력해주세요!"),
         ],
         ephemeral: true,
       });
@@ -204,9 +205,9 @@ export default class UserService {
       interaction.reply({
         embeds: [
           new EmbedBuilder()
+            .setColor(PColors.error)
             .setTitle("이런!")
-            .setDescription(battleTag + "님의 프로필이 없습니다!")
-            .setColor(Colors.Red),
+            .setDescription(battleTag + "님의 프로필이 없습니다!"),
         ],
         ephemeral: true,
       });
@@ -215,41 +216,44 @@ export default class UserService {
 
     interaction.reply({
       embeds: [
-        new EmbedBuilder().setTitle(battleTag + "님의 프로필").setFields(
-          {
-            name: "닉네임",
-            value: user.profile.nickname,
-            inline: true,
-          },
-          {
-            name: "클랜명",
-            value: user.profile.clanname || "비어있음",
-            inline: true,
-          },
-          {
-            name: "포지션",
-            value:
-              { light: "소형", middle: "중형", heavy: "대형" }[
-                user.profile.position ?? ""
-              ] || "비어있음",
-            inline: true,
-          },
-          {
-            name: "주특기",
-            value: user.profile.ability || "비어있음",
-            inline: true,
-          },
-          {
-            name: "무기",
-            value: user.profile.weapon || "비어있음",
-            inline: true,
-          },
-          {
-            name: "가젯",
-            value: user.profile.gadget.join(", "),
-            inline: true,
-          },
-        ),
+        new EmbedBuilder()
+          .setColor(PColors.primary)
+          .setTitle(battleTag + "님의 프로필")
+          .setFields(
+            {
+              name: "닉네임",
+              value: user.profile.nickname,
+              inline: true,
+            },
+            {
+              name: "클랜명",
+              value: user.profile.clanname || "비어있음",
+              inline: true,
+            },
+            {
+              name: "포지션",
+              value:
+                { light: "소형", middle: "중형", heavy: "대형" }[
+                  user.profile.position ?? ""
+                ] || "비어있음",
+              inline: true,
+            },
+            {
+              name: "주특기",
+              value: user.profile.ability || "비어있음",
+              inline: true,
+            },
+            {
+              name: "무기",
+              value: user.profile.weapon || "비어있음",
+              inline: true,
+            },
+            {
+              name: "가젯",
+              value: user.profile.gadget.join(", "),
+              inline: true,
+            },
+          ),
       ],
     });
   }

--- a/src/discord/embeds/AlertMessageManager.ts
+++ b/src/discord/embeds/AlertMessageManager.ts
@@ -1,5 +1,6 @@
 import Discord from "discord.js";
 import MessageManager from "./MessageManager";
+import PColors from "@/constants/PColors";
 
 export default class AlertMessageManager<
   R extends Discord.RepliableInteraction | Discord.Message,
@@ -15,6 +16,7 @@ export default class AlertMessageManager<
     super(responseObject);
     this.messageData.embeds = [
       new Discord.EmbedBuilder()
+        .setColor(PColors.primary)
         .setTitle(title || null)
         .setColor(Discord.Colors.Blue)
         .setDescription(description || null)

--- a/src/discord/features/InviteLinkRemover.ts
+++ b/src/discord/features/InviteLinkRemover.ts
@@ -1,0 +1,19 @@
+import Vars from "@/Vars";
+import { Discord, On } from "discordx";
+
+@Discord()
+export default class InviteLinkRemover {
+  @On({ event: "messageCreate" })
+  private async messageCreate(
+    [message]: DiscordX.ArgsOf<"messageCreate">,
+    client: DiscordX.Client,
+  ) {
+    const matchArr = message.content.match(/discord.gg\/([A-Za-z0-9]+)/);
+    if (!matchArr) return;
+    const inviteCode = matchArr[1];
+    const result = (await client.rest.get(`/invites/${inviteCode}`, {})) as any;
+    if (Vars.banInviteGuilds.includes(result.guild.id)) {
+      message.delete();
+    }
+  }
+}

--- a/src/discord/features/MatchMaker.ts
+++ b/src/discord/features/MatchMaker.ts
@@ -12,6 +12,7 @@ import { Discord, On } from "discordx";
 import FixedMessageRegister from "../../core/FixedMessageRegister";
 import VoiceChannelManager from "../../core/VoiceChannelManager";
 import Vars from "@/Vars";
+import PColors from "@/constants/PColors";
 
 const MAX_MATCH = 3;
 const keyMap = {
@@ -158,6 +159,7 @@ export default class MatchMaker {
       content: null,
       embeds: [
         new EmbedBuilder()
+          .setColor(PColors.primary)
           .setTitle("매치메이커")
           .setDescription(
             `
@@ -283,13 +285,16 @@ class MatchMakingSession {
 
     return {
       embeds: [
-        new EmbedBuilder().setTitle("매치메이킹 하는중...").setDescription(
-          `
+        new EmbedBuilder()
+          .setColor(PColors.primary)
+          .setTitle("매치메이킹 하는중...")
+          .setDescription(
+            `
 * 모드: ${keyMap[this.context.type]}
 * 모집인원: ~${MAX_MATCH}인
 * 디소코드의 개인 보안으로 인해 ⁠THE FINALS TEAMS ⁠대기실에 먼저 입장해야 합니다.
 * 현재 대기 중인 팀원:` + usersStr,
-        ),
+          ),
       ],
       components: [
         new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -317,7 +322,9 @@ class MatchMakingSession {
   buildCancelMessage() {
     return {
       embeds: [
-        new EmbedBuilder().setTitle("매치메이킹 취소됨").setDescription(`
+        new EmbedBuilder()
+          .setColor(PColors.primary)
+          .setTitle("매치메이킹 취소됨").setDescription(`
 * 누군가에 의해 매치메이킹이 취소되었습니다.
 * 다시 매치메이킹을 시작하려면 아래 버튼을 눌러주세요.`),
       ],

--- a/src/discord/features/RoomsMaker.ts
+++ b/src/discord/features/RoomsMaker.ts
@@ -2,14 +2,14 @@ import FixedMessageRegister from "@/core/FixedMessageRegister";
 import Vars from "@/Vars";
 import VoiceChannelManager from "@/core/VoiceChannelManager";
 import autoDeleteMessage from "@/utils/autoDeleteMessage";
-import { EmbedBuilder } from "@discordjs/builders";
 import {
+  EmbedBuilder,
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
-  Colors,
 } from "discord.js";
 import { ButtonComponent, Discord } from "discordx";
+import PColors from "@/constants/PColors";
 
 const roomEmbedDescriptions: Record<string, string> = {
   고랭크: "고랭크(플레티넘~최대) 토너먼트 파티 구인구직 가능합니다.",
@@ -44,12 +44,12 @@ export default class RoomsMaker {
     return {
       embeds: [
         new EmbedBuilder()
+          .setColor(PColors.primary)
           .setTitle(name + " 음성방 생성")
           .setDescription(
             `${roomEmbedDescriptions[name]}
 음성방을 생성하려면 아래 버튼을 눌러주세요.`,
           )
-          .setColor(Colors.Green)
           .setFooter({ text: "THE FINALS TEAMS" }),
       ],
       components: [

--- a/src/utils/sendConfirmMessage.ts
+++ b/src/utils/sendConfirmMessage.ts
@@ -6,6 +6,7 @@ import {
   ComponentType,
 } from "discord.js";
 import onlyOwner from "./onlyOwner";
+import PColors from "@/constants/PColors";
 
 export default async function sendConfirmMessage(
   content: string | Discord.EmbedBuilder,
@@ -29,7 +30,7 @@ export default async function sendConfirmMessage(
 ): Promise<boolean | null> {
   const embed =
     typeof content === "string"
-      ? new EmbedBuilder({ description: content })
+      ? new EmbedBuilder({ description: content }).setColor(PColors.primary)
       : content;
   const buttons = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder({


### PR DESCRIPTION
서버에 깡통 계정으로 특정 서버의 초대 링크가 지속적으로 들어오고 있었습니다.
초대 링크가 고정된 것이 아니라서 discord rest api를 사용하여 guild id를 통해 메시지를 삭제시키게 했습니다.

* 환경변수: `BAN_INVITE_GUILDS` 가 추가됐습니다. guild id들을 ,로 구분하여 나열합니다.