### PR TITLE
fix: 레거시 고정 메시지를 삭제하는 것을 기다리지 않음

### DIFF
--- a/src/core/FixedMessageRegister.ts
+++ b/src/core/FixedMessageRegister.ts
@@ -25,7 +25,7 @@ export default class FixedMessageRegister {
     console.time("initalizing FixedMessageRegister...");
     const messages = await FixedMessageModel.find();
     await Promise.all(
-      messages.map(async (fixedMessageData) => {
+      messages.map((fixedMessageData) =>
         Promise.all([
           Vars.mainGuild.channels
             .fetch(fixedMessageData.channelId)
@@ -38,11 +38,10 @@ export default class FixedMessageRegister {
           FixedMessageModel.deleteOne({
             messageId: fixedMessageData.messageId,
           }),
-        ]);
-      }),
-    );
-
-    console.timeEnd("initalizing FixedMessageRegister...");
+        ]),
+      ),
+    ),
+      console.timeEnd("initalizing FixedMessageRegister...");
   }
 
   public static async sendMessage(


### PR DESCRIPTION
FixedMessageRegister에선 mongodb에 캐싱된 최신 고정 메시지 id를 가져와 메시지를 삭제함으로써 *봇이 재시작됐을 때 고정 메시지가 중복되는 일*을 방지하고 있습니다.

다른 이슈를 해결하던 와중 아래 코드에서 레거시 고정 메시지를 삭제하는 작업을 await하지 않는 것을 확인하여 고쳤습니다. 
```ts
// FixedMessageRegister.ts
    await Promise.all(
      messages.map(async (fixedMessageData) => {
        Promise.all([ // ! not awaiting!
          Vars.mainGuild.channels
            .fetch(fixedMessageData.channelId)
            .then((channel) =>
              (channel as Discord.TextBasedChannel).messages.fetch(
                fixedMessageData.messageId,
              ),
            )
            .then((message) => message.delete()),
          FixedMessageModel.deleteOne({
            messageId: fixedMessageData.messageId,
          }),
        ]);
      }),
    );
 ```