### PR TITLE
feat: 방 생성자에게 방 관리자 권한 부여

### DIFF
--- a/src/core/VoiceChannelManager.ts
+++ b/src/core/VoiceChannelManager.ts
@@ -44,9 +44,14 @@ export default class VoiceChannelManager {
 
   public static async createVoiceChannel(
     name: string,
-    removeTime = 1000 * 7,
-    parent: Discord.CategoryChannelResolvable = process.env
-      .MATCHMAKED_ROOM_CATEGORY_ID,
+    {
+      removeTime = 1000 * 7,
+      parent = process.env.MATCHMAKED_ROOM_CATEGORY_ID,
+      owner,
+    }: CreateVoiceChannelOptions = {
+      removeTime: 1000 * 7,
+      parent: process.env.MATCHMAKED_ROOM_CATEGORY_ID,
+    },
   ) {
     const channel = await Vars.mainGuild.channels.create({
       type: ChannelType.GuildVoice,
@@ -61,7 +66,18 @@ export default class VoiceChannelManager {
         removeTime,
       ),
     };
+    if (owner) {
+      channel.permissionOverwrites.create(owner.id, {
+        Administrator: true,
+      });
+    }
     this.voiceChannels.set(channel.id, data);
     return channel;
   }
+}
+
+interface CreateVoiceChannelOptions {
+  owner?: Discord.User;
+  removeTime?: number;
+  parent?: Discord.CategoryChannelResolvable;
 }

--- a/src/discord/features/MatchMaker.ts
+++ b/src/discord/features/MatchMaker.ts
@@ -123,6 +123,7 @@ export default class MatchMaker {
       case "free_match_button":
         const voiceChannel = await VoiceChannelManager.createVoiceChannel(
           `${keyMap.free} 매치메이킹`,
+          { owner: interaction.user },
         );
         await autoDeleteMessage(
           interaction.reply({
@@ -149,7 +150,7 @@ export default class MatchMaker {
     }
 
     await this.rerender();
-    await this.validateMatch();
+    await this.validateMatch(interaction);
     await this.rerender();
   }
 
@@ -204,11 +205,15 @@ ${bold("대기자 수")}`,
     }
   }
 
-  async validateMatch() {
+  async validateMatch(interaction: Discord.RepliableInteraction) {
     for (const [key, queue] of Object.entries(this.matchQueue)) {
       if (queue.length < MAX_MATCH) continue;
 
-      const context = new MatchMakingContext(this, key as MatchMakingType);
+      const context = new MatchMakingContext(
+        this,
+        key as MatchMakingType,
+        interaction.user,
+      );
       while (context.sessions.length < MAX_MATCH) {
         const user = queue.shift()!;
         context.sessions.push(new MatchMakingSession(user, context));
@@ -226,11 +231,13 @@ class MatchMakingContext {
   constructor(
     public readonly matchMaker: MatchMaker,
     public readonly type: MatchMakingType,
+    public readonly craetor: Discord.User,
   ) {}
 
   async createRoom() {
     const voiceChannel = await VoiceChannelManager.createVoiceChannel(
       `${keyMap[this.type]} 매치메이킹`,
+      { owner: this.craetor },
     );
     this.voiceChannel = voiceChannel;
 

--- a/src/discord/features/RoomsMaker.ts
+++ b/src/discord/features/RoomsMaker.ts
@@ -70,7 +70,9 @@ export default class RoomsMaker {
         interaction.message.components[0]
           .components[0] as Discord.ButtonComponent
       ).label?.split(/\s/)[0] || "") + " 대화방";
-    const voiceChannel = await VoiceChannelManager.createVoiceChannel(name);
+    const voiceChannel = await VoiceChannelManager.createVoiceChannel(name, {
+      owner: interaction.user,
+    });
     await autoDeleteMessage(
       interaction.reply({
         content: `${name}이 생성되었습니다. 


### PR DESCRIPTION
매치메이킹, 대화방 생성 등에서 음성 채널을 만든 사람이 채널 설정을 가능케 만듦

**우려 사항**: 관리자 권한을 부여받으면 서버 관리자가 통제할 수 없는 경우가 존재할까?
**부가적 변경 사항**: `VoiceChannelManager.createVoiceChannel`의 인자 변경 - 길게 늘어진 4개의 옵션 인자를 하나의 옵션 객체로 통일