### PR TITLE
방 생성 기능 개선

### DIFF
--- a/src/Vars.ts
+++ b/src/Vars.ts
@@ -4,22 +4,38 @@ import { SatoriOptions } from "satori/wasm";
 import fs from "fs";
 import path from "path";
 import { promisify } from "util";
+import FixedMessageModel from "./models/FixedMessagesModel";
+import RoomMakingDataModel from "./models/RoomMakingDataModel";
 
 export default class Vars {
+  // in djs, .env
   static client: DiscordX.Client;
   static mainGuild: Discord.Guild;
   static masterUsers: Discord.User[] = [];
+
+  // in DB
+  static roomMakingAnnounceData: Record<
+    string,
+    {
+      channel: Discord.TextChannel;
+      name: string;
+      description: string;
+    }
+  > = {};
   static roomMakingAnnounceChannels: Discord.TextChannel[] = [];
   static dmLogChannel: Discord.TextChannel;
   static matchMakingAnnounceChannel: Discord.TextChannel;
   static matchMakingWaitingChannel: Discord.VoiceBasedChannel;
   static matchMakingCategory: Discord.CategoryChannel;
   static banInviteGuilds: string[];
+
+  // in public
   static font: SatoriOptions["fonts"][number];
   static images: Record<string, string> = {};
 
   public static async init(client: DiscordX.Client): Promise<void> {
     Vars.client = client;
+
     await Promise.all([
       promisify(fs.readdir)(
         path.resolve(import.meta.dirname, "../public/images/ranks"),
@@ -56,8 +72,23 @@ export default class Vars {
       ...process.env.MASTER_USERS.split(",").map((id) =>
         client.users.fetch(id).then((u) => Vars.masterUsers.push(u)),
       ),
+      RoomMakingDataModel.find().then((data) =>
+        Promise.all(
+          data.map(async (d) => {
+            const channel = await client.channels
+              .fetch(d.channelId)
+              .then((c) => Vars.validateChannel(c, ChannelType.GuildText));
+            Vars.roomMakingAnnounceData[channel.id] = {
+              channel,
+              name: d.name,
+              description: d.description,
+            };
+          }),
+        ),
+      ),
     ]);
   }
+
   public static async initServerSetting(client: DiscordX.Client) {
     const serverSettings = ServerSettingManager.main.getSetting();
     if (!serverSettings) throw new Error("ServerSettings not found");

--- a/src/Vars.ts
+++ b/src/Vars.ts
@@ -9,7 +9,7 @@ export default class Vars {
   static client: DiscordX.Client;
   static mainGuild: Discord.Guild;
   static masterUsers: Discord.User[] = [];
-  static roomMakingAnnounceChannels: Record<string, Discord.TextChannel> = {};
+  static roomMakingAnnounceChannels: Discord.TextChannel[] = [];
   static dmLogChannel: Discord.TextChannel;
   static matchMakingAnnounceChannel: Discord.TextChannel;
   static matchMakingWaitingChannel: Discord.VoiceBasedChannel;
@@ -62,13 +62,11 @@ export default class Vars {
     const serverSettings = ServerSettingManager.main.getSetting();
     if (!serverSettings) throw new Error("ServerSettings not found");
     await Promise.all([
-      ...Array.from(
-        serverSettings.channels.roomMakingAnnounceChannels.entries(),
-      ).map(async ([name, id]) =>
+      ...serverSettings.channels.roomMakingAnnounceChannels.map(async (id) =>
         client.channels
           .fetch(id)
           .then((c) => Vars.validateChannel(c, ChannelType.GuildText))
-          .then((c) => (Vars.roomMakingAnnounceChannels[name] = c)),
+          .then((c) => Vars.roomMakingAnnounceChannels.push(c)),
       ),
       client.channels
         .fetch(serverSettings.channels.dmLogChannelId)

--- a/src/Vars.ts
+++ b/src/Vars.ts
@@ -4,7 +4,6 @@ import { SatoriOptions } from "satori/wasm";
 import fs from "fs";
 import path from "path";
 import { promisify } from "util";
-import FixedMessageModel from "./models/FixedMessagesModel";
 import RoomMakingDataModel from "./models/RoomMakingDataModel";
 
 export default class Vars {
@@ -22,7 +21,6 @@ export default class Vars {
       description: string;
     }
   > = {};
-  static roomMakingAnnounceChannels: Discord.TextChannel[] = [];
   static dmLogChannel: Discord.TextChannel;
   static matchMakingAnnounceChannel: Discord.TextChannel;
   static matchMakingWaitingChannel: Discord.VoiceBasedChannel;
@@ -93,12 +91,6 @@ export default class Vars {
     const serverSettings = ServerSettingManager.main.getSetting();
     if (!serverSettings) throw new Error("ServerSettings not found");
     await Promise.all([
-      ...serverSettings.channels.roomMakingAnnounceChannels.map(async (id) =>
-        client.channels
-          .fetch(id)
-          .then((c) => Vars.validateChannel(c, ChannelType.GuildText))
-          .then((c) => Vars.roomMakingAnnounceChannels.push(c)),
-      ),
       client.channels
         .fetch(serverSettings.channels.dmLogChannelId)
         .then((c) => Vars.validateChannel(c, ChannelType.GuildText))

--- a/src/core/ServerSettingManager.ts
+++ b/src/core/ServerSettingManager.ts
@@ -67,9 +67,17 @@ export default class ServerSettingManager {
   }
 
   async requestSettingInit(guild: Discord.Guild) {
+    const allChannels = await guild.channels.fetch();
+    await Promise.all(
+      allChannels.map(async (channel) => {
+        if (channel?.name !== "server-init") return;
+        await channel.delete();
+      }),
+    );
+
     const channel = await guild.channels.create({
       type: ChannelType.GuildText,
-      name: "server init",
+      name: "server-init",
       permissionOverwrites: [
         ...Vars.masterUsers.map(
           (user) =>
@@ -101,7 +109,7 @@ export default class ServerSettingManager {
           matchmakedCategoryId: "",
           matchmakingAnnounceChannelId: "",
           matchmakingWaitingChannelId: "",
-          roomMakingAnnounceChannels: {},
+          roomMakingAnnounceChannels: [],
           invalidInviteGuilds: [],
         },
       });

--- a/src/core/ServerSettingManager.ts
+++ b/src/core/ServerSettingManager.ts
@@ -35,10 +35,6 @@ const channelMap: Record<
     type: "channel",
   },
   invalidInviteGuilds: { name: "초대링크 차단된 서버들", type: "guild" },
-  roomMakingAnnounceChannels: {
-    name: "방 생성 고정임베드 채널",
-    type: "channel",
-  },
 };
 export default class ServerSettingManager {
   static #main: ServerSettingManager;
@@ -109,7 +105,6 @@ export default class ServerSettingManager {
           matchmakedCategoryId: "",
           matchmakingAnnounceChannelId: "",
           matchmakingWaitingChannelId: "",
-          roomMakingAnnounceChannels: [],
           invalidInviteGuilds: [],
         },
       });

--- a/src/core/ServerSettingManager.ts
+++ b/src/core/ServerSettingManager.ts
@@ -110,8 +110,9 @@ export default class ServerSettingManager {
       });
     const interaction = await channel
       .send({
-        content:
-          "서버 설정이 준비되었습니다.\n세부 설정 버튼을 눌러 서버 설정을 완료하세요.",
+        content: `서버 설정이 없습니다.
+세부 설정 버튼을 눌러 서버 설정을 완료하세요.
+${bold("서버 설정을 완료치 않으면 봇 기능을 이용할 수 없습니다!")}`,
         components: [
           new ActionRowBuilder<ButtonBuilder>().addComponents(
             new ButtonBuilder()
@@ -149,6 +150,7 @@ export default class ServerSettingManager {
     await setting.save();
     msg.push("* 설정이 완료되었습니다!");
     await render();
+    this.settingMap.set(guild.id, setting);
   }
 
   private async resolveSettingInput(

--- a/src/core/ServerSettingManager.ts
+++ b/src/core/ServerSettingManager.ts
@@ -176,7 +176,6 @@ export default class ServerSettingManager {
           value: value as string,
         },
       );
-      await input.update();
       return [
         input.value && this.serializeValue(input.value),
         input.getValueString(),
@@ -190,7 +189,6 @@ export default class ServerSettingManager {
           value: value as string[],
         },
       );
-      await input.update();
 
       return [
         input.value.map((v) => this.serializeValue(v)),
@@ -205,7 +203,6 @@ export default class ServerSettingManager {
           value: value as Record<string, string>,
         },
       );
-      await input.update();
 
       return [
         Object.fromEntries(

--- a/src/discord/commands/ServerSettingService.ts
+++ b/src/discord/commands/ServerSettingService.ts
@@ -2,13 +2,33 @@ import ServerSettingManager from "@/core/ServerSettingManager";
 import ServerSettingModel from "@/models/ServerSetting";
 import autoDeleteMessage from "@/utils/autoDeleteMessage";
 import { PermissionGuard } from "@discordx/utilities";
-import { Discord, Guard, Slash, SlashGroup } from "discordx";
+import { Discord, Guard, Slash, SlashGroup, SlashOption } from "discordx";
 import MasterGuard from "../guards/MasterGuard";
+import {
+  ApplicationCommandOptionType,
+  ChannelType,
+  Colors,
+  EmbedBuilder,
+} from "discord.js";
+import ErrorMessageManager from "../messageManagers/ErrorMessageManager";
+import Vars from "@/Vars";
+import sendConfirmMessage from "@/utils/sendConfirmMessage";
+import PrimitiveInputMessageManager from "../messageManagers/inputs/PrimitiveInputMessageManager";
+import {
+  InputResolvers,
+  TextInputResolver,
+} from "../messageManagers/inputs/InputResolvers";
+import RoomMakingDataModel from "@/models/RoomMakingDataModel";
 
 @Discord()
+@SlashGroup({
+  name: "서버설정",
+  description: "이 서버에 대한 여러 설정을 관리합니다.",
+})
 @Guard(PermissionGuard(["Administrator"]), MasterGuard)
 export class ServerSettingService {
-  @Slash({ name: "서버설정", description: "서버 설정 명령어" })
+  @SlashGroup("서버설정")
+  @Slash({ name: "초기화", description: "서버 채널 설정을 새로 정합니다." })
   async setting(interaction: Discord.ChatInputCommandInteraction) {
     interaction.deferReply({ ephemeral: true });
     const serverSettings = await ServerSettingModel.findOne({
@@ -20,5 +40,108 @@ export class ServerSettingService {
     }
     autoDeleteMessage(interaction.reply("채널 설정을 변경합니다."), 1500);
     await ServerSettingManager.main.requestSettingInit(interaction.guild!);
+  }
+
+  @SlashGroup("서버설정")
+  @Slash({
+    name: "방생성",
+    description: "해당 채널에 대한 파티방 생성 정보를 수정합니다.",
+  })
+  async roomMakingChannelSetting(
+    @SlashOption({
+      name: "채널",
+      description: "방 생성 정보를 수정할 채널",
+      required: true,
+      type: ApplicationCommandOptionType.Channel,
+    })
+    channel: Discord.TextChannel,
+    interaction: Discord.ChatInputCommandInteraction,
+  ) {
+    if (!interaction.channel) return;
+    if (channel.type !== ChannelType.GuildText) {
+      autoDeleteMessage(
+        new ErrorMessageManager.Builder()
+          .send("interaction", interaction, {
+            description: "텍스트 채널이어야 합니다.",
+          })
+          .then((m) => m.message),
+      );
+      return;
+    }
+
+    await interaction.deferReply();
+
+    const isInSetting = !!Vars.roomMakingAnnounceChannels.find(
+      (c) => c.id == channel.id,
+    );
+    if (!isInSetting) {
+      const confirmed = await sendConfirmMessage(
+        new EmbedBuilder()
+          .setTitle("해당 채널은 설정에 없는 채널입니다.")
+          .setDescription("설정에 추가하시겠습니까?")
+          .setColor(Colors.DarkBlue),
+        interaction,
+        {},
+      );
+
+      if (!confirmed) {
+        autoDeleteMessage(interaction.reply("취소되었습니다."), 1500);
+        return;
+      }
+      if (confirmed) {
+        Vars.roomMakingAnnounceChannels.push(channel);
+        await ServerSettingModel.updateOne(
+          {
+            guildId: interaction.guildId,
+            botId: interaction.client.user!.id,
+          },
+          {
+            $addToSet: {
+              "channels.roomMakingAnnounceChannels": channel.id,
+            },
+          },
+        );
+        autoDeleteMessage(
+          interaction.channel.send("채널이 추가되었습니다."),
+          1500,
+        );
+      } else {
+        autoDeleteMessage(interaction.channel.send("취소되었습니다."), 1500);
+      }
+    }
+
+    const nameAskMsg = await interaction.channel.send("이름을 입력해주세요.");
+    const name = await new PrimitiveInputMessageManager.Builder().send(
+      "channel",
+      interaction.channel,
+      {
+        inputResolver: InputResolvers.text,
+        value: Vars.roomMakingAnnounceData[channel.id]?.name,
+      },
+    );
+    await nameAskMsg.delete();
+
+    const descriptionAskMsg =
+      await interaction.channel.send("설명을 입력해주세요.");
+    const description = await new PrimitiveInputMessageManager.Builder().send(
+      "channel",
+      interaction.channel,
+      {
+        inputResolver: new TextInputResolver(),
+        value: Vars.roomMakingAnnounceData[channel.id]?.description,
+      },
+    );
+    await descriptionAskMsg.delete();
+
+    await RoomMakingDataModel.updateOne(
+      { channelId: channel.id },
+      { name: name.value, description: description.value },
+      { upsert: true },
+    );
+
+    autoDeleteMessage(
+      interaction.channel.send("방 정보가 수정되었습니다."),
+      1500,
+    );
   }
 }

--- a/src/discord/commands/ServerSettingService.ts
+++ b/src/discord/commands/ServerSettingService.ts
@@ -4,15 +4,9 @@ import autoDeleteMessage from "@/utils/autoDeleteMessage";
 import { PermissionGuard } from "@discordx/utilities";
 import { Discord, Guard, Slash, SlashGroup, SlashOption } from "discordx";
 import MasterGuard from "../guards/MasterGuard";
-import {
-  ApplicationCommandOptionType,
-  ChannelType,
-  Colors,
-  EmbedBuilder,
-} from "discord.js";
+import { ApplicationCommandOptionType, ChannelType } from "discord.js";
 import ErrorMessageManager from "../messageManagers/ErrorMessageManager";
 import Vars from "@/Vars";
-import sendConfirmMessage from "@/utils/sendConfirmMessage";
 import PrimitiveInputMessageManager from "../messageManagers/inputs/PrimitiveInputMessageManager";
 import {
   InputResolvers,
@@ -69,46 +63,7 @@ export class ServerSettingService {
       return;
     }
 
-    await interaction.deferReply();
-
-    const isInSetting = !!Vars.roomMakingAnnounceChannels.find(
-      (c) => c.id == channel.id,
-    );
-    if (!isInSetting) {
-      const confirmed = await sendConfirmMessage(
-        new EmbedBuilder()
-          .setTitle("해당 채널은 설정에 없는 채널입니다.")
-          .setDescription("설정에 추가하시겠습니까?")
-          .setColor(Colors.DarkBlue),
-        interaction,
-        {},
-      );
-
-      if (!confirmed) {
-        autoDeleteMessage(interaction.reply("취소되었습니다."), 1500);
-        return;
-      }
-      if (confirmed) {
-        Vars.roomMakingAnnounceChannels.push(channel);
-        await ServerSettingModel.updateOne(
-          {
-            guildId: interaction.guildId,
-            botId: interaction.client.user!.id,
-          },
-          {
-            $addToSet: {
-              "channels.roomMakingAnnounceChannels": channel.id,
-            },
-          },
-        );
-        autoDeleteMessage(
-          interaction.channel.send("채널이 추가되었습니다."),
-          1500,
-        );
-      } else {
-        autoDeleteMessage(interaction.channel.send("취소되었습니다."), 1500);
-      }
-    }
+    await interaction.reply("설정을 시작합니다.");
 
     const nameAskMsg = await interaction.channel.send("이름을 입력해주세요.");
     const name = await new PrimitiveInputMessageManager.Builder().send(
@@ -135,7 +90,11 @@ export class ServerSettingService {
 
     await RoomMakingDataModel.updateOne(
       { channelId: channel.id },
-      { name: name.value, description: description.value },
+      {
+        channelId: channel.id,
+        name: name.value,
+        description: description.value,
+      },
       { upsert: true },
     );
 

--- a/src/discord/features/MatchMaker.ts
+++ b/src/discord/features/MatchMaker.ts
@@ -45,10 +45,10 @@ export default class MatchMaker {
   public async init(): Promise<void> {
     console.time("initalizing MatchMaker...");
 
-    /* this.#matchMakingMessage = await FixedMessageRegister.sendMessage(
+    this.#matchMakingMessage = await FixedMessageRegister.sendMessage(
       Vars.matchMakingAnnounceChannel,
       "waiting...",
-    );*/
+    );
     await this.rerender();
 
     console.timeEnd("initalizing MatchMaker...");

--- a/src/discord/features/RoomsMaker.ts
+++ b/src/discord/features/RoomsMaker.ts
@@ -10,13 +10,6 @@ import {
 } from "discord.js";
 import { ButtonComponent, Discord } from "discordx";
 import PColors from "@/constants/PColors";
-import ServerSettingManager from "@/core/ServerSettingManager";
-
-const roomEmbedDescriptions: Record<string, string> = {
-  고랭크: "고랭크(플레티넘~최대) 토너먼트 파티 구인구직 가능합니다.",
-  랭크: "랭크 토너먼트 파티 구인구직 가능합니다.",
-  일반: "일반 파티 구인구직 가능합니다.",
-};
 
 @Discord()
 export default class RoomsMaker {
@@ -29,25 +22,16 @@ export default class RoomsMaker {
   public async init(): Promise<void> {
     console.time("initalizing RoomsMaker...");
     await Promise.all(
-      Object.entries(Vars.roomMakingAnnounceChannels).map(([name, channel]) => {
-        FixedMessageRegister.sendMessage(
-          channel,
-          this.buildChannelMessage(name),
-          "keep",
-        );
-      }),
     );
     console.timeEnd("initalizing RoomsMaker...");
   }
 
-  private buildChannelMessage(name: string) {
     return {
       embeds: [
         new EmbedBuilder()
           .setColor(PColors.primary)
           .setTitle(name + " 음성방 생성")
           .setDescription(
-            `${roomEmbedDescriptions[name]}
 음성방을 생성하려면 아래 버튼을 눌러주세요.`,
           )
           .setFooter({ text: "THE FINALS TEAMS" }),

--- a/src/discord/features/RoomsMaker.ts
+++ b/src/discord/features/RoomsMaker.ts
@@ -22,16 +22,26 @@ export default class RoomsMaker {
   public async init(): Promise<void> {
     console.time("initalizing RoomsMaker...");
     await Promise.all(
+      Object.entries(Vars.roomMakingAnnounceData).map(
+        ([channelId, { channel, name, description }]) =>
+          FixedMessageRegister.sendMessage(
+            channel,
+            this.buildChannelMessage(name, description),
+            "keep",
+          ),
+      ),
     );
     console.timeEnd("initalizing RoomsMaker...");
   }
 
+  private buildChannelMessage(name: string, description: string) {
     return {
       embeds: [
         new EmbedBuilder()
           .setColor(PColors.primary)
           .setTitle(name + " 음성방 생성")
           .setDescription(
+            `${description}
 음성방을 생성하려면 아래 버튼을 눌러주세요.`,
           )
           .setFooter({ text: "THE FINALS TEAMS" }),

--- a/src/discord/messageManagers/inputs/ArrayInputMessageManager.ts
+++ b/src/discord/messageManagers/inputs/ArrayInputMessageManager.ts
@@ -48,7 +48,6 @@ export default class ArrayInputMessageManager<
 * ${this.inputResolver.getDescription()}
 * 입력을 마치려면 👍이모지를 눌러주세요.
 * 현재 입력된 값: ${this.getValueString()}`;
-    super.update();
-    return this.message;
+    return super.update();
   }
 }

--- a/src/discord/messageManagers/inputs/ArrayInputMessageManager.ts
+++ b/src/discord/messageManagers/inputs/ArrayInputMessageManager.ts
@@ -26,6 +26,7 @@ export default class ArrayInputMessageManager<
       value: options.value || [],
       ...options,
     });
+    this.value ??= [];
     this.options.valueValidators = options.valueValidators ?? [];
     this.options.valueValidators.push({
       callback: () =>

--- a/src/discord/messageManagers/inputs/InputResolvers.ts
+++ b/src/discord/messageManagers/inputs/InputResolvers.ts
@@ -1,5 +1,5 @@
 import Vars from "@/Vars";
-import { Routes } from "discord.js";
+import { InputOptions } from "./InputMessageManager";
 
 export abstract class PrimitiveInputResolver<PT extends PrimitiveInputType> {
   constructor() {}
@@ -11,6 +11,9 @@ export abstract class PrimitiveInputResolver<PT extends PrimitiveInputType> {
   abstract resolveInput(
     msg: Discord.Message,
   ): MaybePromise<PT | null | undefined>;
+  getValidate(): NonNullable<InputOptions<PT>["textValidators"]>[number] {
+    return { callback: () => true, invalidMessage: "" };
+  }
 }
 
 export class TextInputResolver extends PrimitiveInputResolver<string> {
@@ -48,6 +51,17 @@ export class ChannelInputResolver extends PrimitiveInputResolver<Discord.Channel
     const channelId = msg.mentions.channels.firstKey() ?? msg.content;
     if (!channelId || !/^\d{17,19}$/.test(channelId)) return null;
     return await Vars.mainGuild.channels.fetch(channelId);
+  }
+
+  override getValidate(): NonNullable<
+    InputOptions<Discord.Channel>["textValidators"]
+  >[number] {
+    return {
+      callback: (value) =>
+        /^<#\d{17,19}>$/.test(value) || /^\d{17,19}$/.test(value),
+      invalidMessage:
+        "입력값은 17자리 또는 19자리 숫자인 채널 ID거나 채녈 멘션이여야 합니다.",
+    };
   }
 }
 

--- a/src/discord/messageManagers/inputs/ObjectInputMessageManager.ts
+++ b/src/discord/messageManagers/inputs/ObjectInputMessageManager.ts
@@ -24,6 +24,7 @@ export default class ObjectInputMessageManager<
       value: options.value || {},
       ...options,
     });
+    this.value ??= {};
     this.options.textValidators = options.textValidators ?? [];
     this.options.textValidators.push({
       callback: (value) => value.includes(":"),

--- a/src/discord/messageManagers/inputs/ObjectInputMessageManager.ts
+++ b/src/discord/messageManagers/inputs/ObjectInputMessageManager.ts
@@ -34,38 +34,41 @@ export default class ObjectInputMessageManager<
   }
 
   protected override async setupCollectors() {
-    this.rCollector.on("collect", async (reaction) => {
-      if (reaction.emoji.name !== "👍" || reaction.count == 1) return;
-      if (!this.value) {
-        autoDeleteMessage(
-          this.message.channel.send("에러: 입력된 값이 없습니다."),
-          1500,
-        );
-        return;
-      }
-      const isConfirmed = await this.askConfirm();
-      if (!isConfirmed) return;
-      this.rCollector.stop();
-      this.mCollector.stop();
-      this.options.onConfirm?.(this.value);
-      this.remove();
-    });
-    this.mCollector.on("collect", async (message) => {
-      if (message.author.id == Vars.client.user!.id) return;
-      this.responsedMessages.push(message);
-      const isTextValid = this.textValidate(message.content);
-      if (!isTextValid) return;
-      const [key, v] = message.content.split(":");
-      message.content = v; // 이거 진짜 맞나
-      const value = await this.inputResolver.resolveInput(message);
-      if (!value) return;
+    return new Promise<void>((res) => {
+      this.rCollector.on("collect", async (reaction) => {
+        if (reaction.emoji.name !== "👍" || reaction.count == 1) return;
+        if (!this.value) {
+          autoDeleteMessage(
+            this.message.channel.send("에러: 입력된 값이 없습니다."),
+            1500,
+          );
+          return;
+        }
+        const isConfirmed = await this.askConfirm();
+        if (!isConfirmed) return;
+        this.rCollector.stop();
+        this.mCollector.stop();
+        this.options.onConfirm?.(this.value);
+        this.remove();
+        res();
+      });
+      this.mCollector.on("collect", async (message) => {
+        if (message.author.id == Vars.client.user!.id) return;
+        this.responsedMessages.push(message);
+        const isTextValid = this.textValidate(message.content);
+        if (!isTextValid) return;
+        const [key, v] = message.content.split(":");
+        message.content = v; // 이거 진짜 맞나
+        const value = await this.inputResolver.resolveInput(message);
+        if (!value) return;
 
-      const isValueValid = this.valueValidate(value);
-      if (!isValueValid) return;
-      message.react("✅");
-      this.responsedMessages.push(message);
-      this.value![key] = value;
-      this.update();
+        const isValueValid = this.valueValidate(value);
+        if (!isValueValid) return;
+        message.react("✅");
+        this.responsedMessages.push(message);
+        this.value![key] = value;
+        this.update();
+      });
     });
   }
 
@@ -76,7 +79,6 @@ export default class ObjectInputMessageManager<
 * "키":"${this.inputResolver.getTypeString()}" 서식에 따라 순서대로 메시지를 보내주세요.
 * 입력을 마치려면 👍이모지를 눌러주세요.
 * 현재 입력된 값: ${this.getValueString()}`;
-    super.update();
-    return this.message;
+    return super.update();
   }
 }

--- a/src/discord/messageManagers/inputs/PrimitiveInputMessageManager.ts
+++ b/src/discord/messageManagers/inputs/PrimitiveInputMessageManager.ts
@@ -33,30 +33,32 @@ export default class PrimitiveInputMessageManager<
     this.messageData.content = `입력 대기중...
 * 입력을 위한 ${this.inputResolver.getTypeString()} 메시지를 보내주세요.
 * 현재 입력된 값: ${this.getValueString()}`;
-    super.update();
-    return this.message;
+    return super.update();
   }
 
   protected override async setupCollectors() {
-    this.mCollector.on("collect", async (message) => {
-      if (message.author.id == Vars.client.user!.id) return;
-      this.responsedMessages.push(message);
-      const isTextValid = this.textValidate(message.content);
-      if (!isTextValid) return;
-      const value = await this.inputResolver.resolveInput(message);
-      if (!value) return;
+    return new Promise<void>((res) => {
+      this.mCollector.on("collect", async (message) => {
+        if (message.author.id == Vars.client.user!.id) return;
+        this.responsedMessages.push(message);
+        const isTextValid = this.textValidate(message.content);
+        if (!isTextValid) return;
+        const value = await this.inputResolver.resolveInput(message);
+        if (!value) return;
 
-      const isValueValid = this.valueValidate(value);
-      if (!isValueValid) return;
-      message.react("✅");
-      this.handleValue(message, value);
+        const isValueValid = this.valueValidate(value);
+        if (!isValueValid) return;
+        message.react("✅");
+        this.handleValue(message, value);
 
-      const isConfirmed = await this.askConfirm();
-      if (!isConfirmed) return;
-      this.rCollector.stop();
-      this.mCollector.stop();
-      this.options.onConfirm?.(value);
-      this.remove();
+        const isConfirmed = await this.askConfirm();
+        if (!isConfirmed) return;
+        this.rCollector.stop();
+        this.mCollector.stop();
+        this.options.onConfirm?.(value);
+        this.remove();
+        res();
+      });
     });
   }
 }

--- a/src/models/FixedMessagesModel.ts
+++ b/src/models/FixedMessagesModel.ts
@@ -2,8 +2,8 @@ import mongoose, { Schema, Model, HydratedDocument } from "mongoose";
 
 declare global {
   interface FixedMessageData {
-    messageId: string;
-    channelId: string;
+    guildId: string;
+    channels: string[];
   }
 }
 interface FixedMessageModel extends Model<FixedMessageData, {}, {}> {
@@ -12,8 +12,8 @@ interface FixedMessageModel extends Model<FixedMessageData, {}, {}> {
   ): Promise<HydratedDocument<FixedMessageData, {}> | undefined>;
 }
 const fixedMessageSchema = new Schema<FixedMessageData, FixedMessageModel, {}>({
-  messageId: { type: String, required: true, unique: true },
-  channelId: { type: String, required: true },
+  guildId: { type: String, required: true, unique: true },
+  channels: { type: [String], required: true, unique: true },
 });
 
 const FixedMessageModel = mongoose.model<FixedMessageData, FixedMessageModel>(

--- a/src/models/RoomMakingDataModel.ts
+++ b/src/models/RoomMakingDataModel.ts
@@ -1,0 +1,29 @@
+import mongoose, { Schema, Model, HydratedDocument } from "mongoose";
+
+declare global {
+  interface RoomMakingDataData {
+    channelId: Discord.Snowflake;
+    name: string;
+    description: string;
+  }
+}
+interface RoomMakingDataModel extends Model<RoomMakingDataData, {}, {}> {
+  findUserByInteration(
+    interaction: Discord.ChatInputCommandInteraction,
+  ): Promise<HydratedDocument<RoomMakingDataData, {}> | undefined>;
+}
+const roomMakingDataSchema = new Schema<
+  RoomMakingDataData,
+  RoomMakingDataModel,
+  {}
+>({
+  channelId: { type: String, required: true, unique: true },
+  name: { type: String, required: true },
+  description: { type: String, required: true },
+});
+
+const RoomMakingDataModel = mongoose.model<
+  RoomMakingDataData,
+  RoomMakingDataModel
+>("RoomMakingData", roomMakingDataSchema);
+export default RoomMakingDataModel;

--- a/src/models/ServerSetting.ts
+++ b/src/models/ServerSetting.ts
@@ -10,7 +10,6 @@ declare global {
       matchmakedCategoryId: Snowflake; // 매치메이킹된 방들이 들어갈 카테고리
       matchmakingAnnounceChannelId: Snowflake; // 매치메이킹 고정임베드 채널
       matchmakingWaitingChannelId: Snowflake; // 매치메이킹 대기방 채널
-      roomMakingAnnounceChannels: Snowflake[]; // 방 생성 고정임베드 채널
       invalidInviteGuilds: Snowflake[]; // 초대링크 차단된 서버들
     };
   }
@@ -21,7 +20,6 @@ export const ChannelsSchema = new Schema<ServerSettingData["channels"]>({
   matchmakedCategoryId: String,
   matchmakingAnnounceChannelId: String,
   matchmakingWaitingChannelId: String,
-  roomMakingAnnounceChannels: [String],
   invalidInviteGuilds: [String],
 });
 

--- a/src/models/ServerSetting.ts
+++ b/src/models/ServerSetting.ts
@@ -10,7 +10,7 @@ declare global {
       matchmakedCategoryId: Snowflake; // 매치메이킹된 방들이 들어갈 카테고리
       matchmakingAnnounceChannelId: Snowflake; // 매치메이킹 고정임베드 채널
       matchmakingWaitingChannelId: Snowflake; // 매치메이킹 대기방 채널
-      roomMakingAnnounceChannels: Map<string, Snowflake>; // 방 생성 고정임베드 채널
+      roomMakingAnnounceChannels: Snowflake[]; // 방 생성 고정임베드 채널
       invalidInviteGuilds: Snowflake[]; // 초대링크 차단된 서버들
     };
   }
@@ -21,10 +21,7 @@ export const ChannelsSchema = new Schema<ServerSettingData["channels"]>({
   matchmakedCategoryId: String,
   matchmakingAnnounceChannelId: String,
   matchmakingWaitingChannelId: String,
-  roomMakingAnnounceChannels: {
-    type: Map,
-    of: String,
-  },
+  roomMakingAnnounceChannels: [String],
   invalidInviteGuilds: [String],
 });
 

--- a/src/utils/sendConfirmMessage.ts
+++ b/src/utils/sendConfirmMessage.ts
@@ -67,6 +67,7 @@ export default async function sendConfirmMessage(
     })
     .catch(() => null);
 
+  await message.delete();
   if (res === null) {
     await interaction.editReply({
       content: timeoutMessage,


### PR DESCRIPTION
* 살린 줄 알았던 서버설정 기능이 InputMessageManager과 같이 동반 살자를 한건지 모조리 다 고장나서 고침
* #8 방 생성 기능은 channel, name, description 3개 요소로 구성돼 있어서 서버설정에 통으로 넣기엔 조금 애매했는데, 그냥 설정을 따로 하는 것으로 해결 (오히려 사용 빈도가 높은 이쪽이 분리되어 변경을 용이하게 만드는게 나음)
* server-init 중복 금지, 완료된 sendConfirmMessage와 버려진 fixedMessage 자동삭제 등 잡버그 수정